### PR TITLE
GitHub Issue descriptions blank after running PnP-Github.ps1

### DIFF
--- a/WARP/devops/PnP-Github.ps1
+++ b/WARP/devops/PnP-Github.ps1
@@ -390,6 +390,8 @@ foreach($item in $assessment.recommendations){
             $body+=$WASAbody
         }
     }
+    #Add $issuebodytext variable for pushing information into GitHub Issue description from the json file as this is called during the addition of issues
+    $issuebodytext = $body
 
     # start gathering labels from the the assesment items and the WASA.json
     $labels = New-Object System.Collections.ArrayList


### PR DESCRIPTION
The $issuebodytext variable was null during running of script.  No issue description was being populated from the WAF.json file. This created all the issues without an additional context