### PR TITLE
Fix for missing security score

### DIFF
--- a/WARP/devops/GenerateWAFReport.ps1
+++ b/WARP/devops/GenerateWAFReport.ps1
@@ -133,6 +133,11 @@ for($i=3; $i -le 8; $i++)
     {
         $securityScore = $Content[$i].Split(',')[2].Trim("'").Split('/')[0]
     }
+    if($Content[$i].Equals(",,,,,"))
+    {
+        #End early if not all pillars assessed
+        Break
+    }
 }
 
 #endregion


### PR DESCRIPTION
This is to fix https://github.com/Azure/WellArchitected-Tools/issues/22

Issue was caused by the for loop including rows beyond the pillar summaries, and matching text from the "Next steps" rows below. This only caused a problem if 1 or 2 pillars were assessed, including the Security pillar.