### PR TITLE
Fixed Get-Rating return values

### DIFF
--- a/WARP/devops/Go-Live/GenerateWAFReport.ps1
+++ b/WARP/devops/Go-Live/GenerateWAFReport.ps1
@@ -174,11 +174,11 @@ function Get-Rating($WeightOrScore)
     { 
         $rating = "Critical"
     }
-    elseif($WeightOrScore -gt 33 -and $WeightOrScore -lt 67)
+    elseif($WeightOrScore -ge 33 -and $WeightOrScore -lt 67)
     { 
         $rating = "Moderate" 
     }
-    elseif($WeightOrScore -gt 67)
+    elseif($WeightOrScore -ge 67)
     { 
         $rating = "Excellent" 
     }


### PR DESCRIPTION
When `$WeightOrScore` was 33 or 67 then result of this method was null which caused errors by PPT generation later.