### PR TITLE
Fixed findingsStart index lookup

### DIFF
--- a/WARP/devops/Go-Live/GenerateWAFReport.ps1
+++ b/WARP/devops/Go-Live/GenerateWAFReport.ps1
@@ -104,7 +104,8 @@ function Read-File($File)
     $content = Get-Content $File
 
     #Get findings
-    $findingsStart = $content.IndexOf("Category,Link-Text,Link,Priority,ReportingCategory,ReportingSubcategory,Weight,Context")
+    $findingsStartIdentifier = $content | Where-Object { $_.Contains("Category,Link-Text,Link,Priority,ReportingCategory,ReportingSubcategory,Weight,Context") } | Select-Object -Unique -First 1
+    $findingsStart = $content.IndexOf($findingsStartIdentifier)
     $endStringIdentifier = $content | Where-Object{$_.Contains("--,,")} | Select-Object -Unique -First 1
     $findingsEnd = $content.IndexOf($endStringIdentifier) - 1
     $findings = $content[$findingsStart..$findingsEnd] | Out-String | ConvertFrom-CSV -Delimiter ","


### PR DESCRIPTION
The structure of the exported CSV from assessment tool has changed without warning (2 columns where added) and original lookup of `findingsStart` was not working anymore. This is a fix for `findingsStart` lookup.